### PR TITLE
fixed field naming regex

### DIFF
--- a/sql_graphviz.py
+++ b/sql_graphviz.py
@@ -52,7 +52,7 @@ def grammar():
     quoted_default_value = "DEFAULT" + quoted_string + OneOrMore(CharsNotIn(", \n\t"))
     quoted_default_value.setParseAction(quoted_default_value_act)
 
-    field_def = OneOrMore(quoted_default_value | Word(alphanums + "_\"'`:-/[]") | parenthesis)
+    field_def = OneOrMore(quoted_default_value | Word(alphanums + "_\"'`:-/[].") | parenthesis)
     field_def.setParseAction(field_act)
 
     tablename_def = ( Word(alphas + "`_.") | QuotedString("\"") )


### PR DESCRIPTION
I could not render the following table:

```sql
CREATE TABLE public.configurationmodel (
    result public.versionstate DEFAULT 'pending'::public.versionstate
);
```

This patch fixes that.