### PR TITLE
add ON UPDATE clause to foreign key definition grammar rule

### DIFF
--- a/sql_graphviz.py
+++ b/sql_graphviz.py
@@ -66,7 +66,9 @@ def grammar():
     create_table_def = Literal("CREATE") + "TABLE" + tablename_def.setResultsName("tableName") + "(" + field_list_def.setResultsName("fields") + ")" + ";"
     create_table_def.setParseAction(create_table_act)
 
-    add_fkey_def = Literal("ALTER") + "TABLE" + "ONLY" + tablename_def.setResultsName("tableName") + "ADD" + "CONSTRAINT" + Word(alphanums + "_") + "FOREIGN" + "KEY" + "(" + Word(alphanums + "_").setResultsName("keyName") + ")" + "REFERENCES" + Word(alphanums + "._").setResultsName("fkTable") + "(" + Word(alphanums + "_").setResultsName("fkCol") + ")" + Optional(Literal("DEFERRABLE")) + Optional(Literal("ON") + "DELETE" + ( Literal("CASCADE") | Literal("RESTRICT") )) + ";"
+    delete_restrict_action = Literal("CASCADE") | Literal("RESTRICT") | Literal("NO ACTION") | ( Literal("SET") + ( Literal("NULL") | Literal("DEFAULT") ))
+
+    add_fkey_def = Literal("ALTER") + "TABLE" + "ONLY" + tablename_def.setResultsName("tableName") + "ADD" + "CONSTRAINT" + Word(alphanums + "_") + "FOREIGN" + "KEY" + "(" + Word(alphanums + "_").setResultsName("keyName") + ")" + "REFERENCES" + Word(alphanums + "._").setResultsName("fkTable") + "(" + Word(alphanums + "_").setResultsName("fkCol") + ")" + Optional(Literal("DEFERRABLE")) + Optional(Literal("ON") + "UPDATE" + delete_restrict_action) + Optional(Literal("ON") + "DELETE" + delete_restrict_action) + ";"
     add_fkey_def.setParseAction(add_fkey_act)
 
     other_statement_def = OneOrMore(CharsNotIn(";")) + ";"


### PR DESCRIPTION
Previously, `ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY ...` statements were dropped by the parser if they contained the `ON UPDATE ...` clause. Consequently, no edges were created for such foreign key constraints. This PR extends the grammar for adding foreign key constraints to also accept `ON UPDATE` clauses, as well as the three additional actions `NO ACTION`, `SET NULL`, and `SET DEFAULT`.