### PR TITLE
Fix quoted literals

### DIFF
--- a/sql_graphviz.py
+++ b/sql_graphviz.py
@@ -83,7 +83,7 @@ def grammar():
         | parenthesis)
     field_def.setParseAction(field_act)
 
-    tablename_def = ( Word(alphanums + "`_.") | QuotedString("\"") )
+    tablename_def = ( ZeroOrMore(Word(alphanums + "`_.")) + Optional(QuotedString("\"")) )
 
     field_list_def = field_def + ZeroOrMore(Suppress(",") + field_def)
     field_list_def.setParseAction(field_list_act)
@@ -113,11 +113,11 @@ def grammar():
         + tablename_def.setResultsName("tableName")
         + CaselessLiteral("ADD")
         + CaselessLiteral("CONSTRAINT")
-        + Word(alphanums + "_")
+        + (Word(alphanums + "_") | QuotedString("\""))
         + CaselessLiteral("FOREIGN")
         + CaselessLiteral("KEY")
         + "(" + fkey_cols.setResultsName("keyName") + ")"
-        + "REFERENCES" + Word(alphanums + "._").setResultsName("fkTable")
+        + "REFERENCES" + tablename_def.setResultsName("fkTable")
         + "(" + fkey_cols.setResultsName("fkCol") + ")"
         + Optional(CaselessLiteral("DEFERRABLE"))
         + Optional(CaselessLiteral("ON") + "UPDATE" + delete_restrict_action)


### PR DESCRIPTION
Example of a `schema.sql` that this tool fails to parse before this PR:

```sql
CREATE TABLE public."Address" (
    id bigint NOT NULL,
    payload bytea NOT NULL
);

CREATE TABLE public."AddressCredentialRelation" (
    address_id bigint NOT NULL,
    credential_id bigint NOT NULL,
    relation integer NOT NULL
);


ALTER TABLE ONLY public."AddressCredentialRelation"
    ADD CONSTRAINT "fk-address_credential-address_id" FOREIGN KEY (address_id) REFERENCES public."Address"(id);
```